### PR TITLE
Issues regarding capital letters from yaml, small fix to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You can build this as a ros2 package with colcon: `colcon build --packages-selec
 Glider can be built as a ros packages in your ros workspace with `catkin build`.
 Run glider with:
 ```
-ros2 launch glider glider-node.launch
+ros2 launch glider glider-node.launch.py
 ```
 
 Everything will be rotated into the ENU frame, includeing the IMU orientation and the Odometry pose. Since GPS is the main prior, we publish state estimates in the ENU frame with UTM coordinates as an `Odometry` ros message or a `NavSatFix` message. This can be configured in `config/ros_params.yaml` with the `publish_nav_sat_fix` parameter.

--- a/glider/config/vectornav-vn100t.yaml
+++ b/glider/config/vectornav-vn100t.yaml
@@ -16,6 +16,6 @@ imu_frame: "enu"
 scale_odom: true
 correct_imu: true
 gps_to_imu:
-  X: 0.0
+  x: 0.0
   y: 0.0
   z: 0.0


### PR DESCRIPTION
Not sure how you want to handle ros2 versions specifically, but there were two things I found when working on Jazzy
the XYZ fields in a yaml file were capital and cpp fails to convert them, and then small fix to the readme regarding the launch command